### PR TITLE
Download folder

### DIFF
--- a/look-and-feel/contents/layouts/org.kde.plasma.desktop-layout.js
+++ b/look-and-feel/contents/layouts/org.kde.plasma.desktop-layout.js
@@ -38,7 +38,7 @@ var downloads = dock.addWidget("org.kde.plasma.folder")
 downloads.currentConfigGroup = ["General"]
 downloads.writeConfig("labelMode","3")
 downloads.writeConfig("labelText","Downloads")
-downloads.writeConfig("url","file:///home/hide/Downloads")
+downloads.writeConfig("url",`${userDataPath("downloads")}`)
 
 dock.addWidget("org.kde.plasma.trash")
 


### PR DESCRIPTION
your script actually adds the "org.kde.plasma.folder" widget however it doesn't lead to any folder, since you added a non-existent address, besides generating a very ugly icon

The change that I propose finds the download directory automatically, so I avoid this error